### PR TITLE
use single curl and parse json twice locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,18 @@ RUN \
  echo "**** install lidarr ****" && \
  mkdir -p /app/lidarr && \
  if [ -z ${LIDARR_RELEASE+x} ]; then \
-	LIDARR_RELEASE=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux" \
-	| jq -r '.[0].version'); \
+ LIDARR_JSON=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux") && \
+ LIDARR_RELEASE=$(jq -n "$LIDARR_JSON" | jq -r '.[0].version') && \
+ LIDARR_URL=$(jq -n "$LIDARR_JSON" | jq -r '.[0].url'); \
  fi && \
- lidarr_url=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux" \
-	| jq -r "first(.[] | select(.version == \"${LIDARR_RELEASE}\")) | .url") && \
+ set -ex && \
  curl -o \
  /tmp/lidarr.tar.gz -L \
-	"${lidarr_url}" && \
+	"${LIDARR_URL}" && \
  tar ixzf \
  /tmp/lidarr.tar.gz -C \
 	/app/lidarr --strip-components=1 && \
+ set +ex && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -19,22 +19,23 @@ RUN \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install --no-install-recommends -y \
-        libchromaprint-tools \
-        jq && \
+	libchromaprint-tools \
+	jq && \
  echo "**** install lidarr ****" && \
  mkdir -p /app/lidarr && \
  if [ -z ${LIDARR_RELEASE+x} ]; then \
-	LIDARR_RELEASE=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux" \
-	| jq -r '.[0].version'); \
+ LIDARR_JSON=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux") && \
+ LIDARR_RELEASE=$(jq -n "$LIDARR_JSON" | jq -r '.[0].version') && \
+ LIDARR_URL=$(jq -n "$LIDARR_JSON" | jq -r '.[0].url'); \
  fi && \
- lidarr_url=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux" \
-	| jq -r "first(.[] | select(.version == \"${LIDARR_RELEASE}\")) | .url") && \
+ set -ex && \
  curl -o \
  /tmp/lidarr.tar.gz -L \
-	"${lidarr_url}" && \
+	"${LIDARR_URL}" && \
  tar ixzf \
  /tmp/lidarr.tar.gz -C \
 	/app/lidarr --strip-components=1 && \
+ set +ex && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -19,22 +19,23 @@ RUN \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install --no-install-recommends -y \
-        libchromaprint-tools \
-        jq && \
+	libchromaprint-tools \
+	jq && \
  echo "**** install lidarr ****" && \
  mkdir -p /app/lidarr && \
  if [ -z ${LIDARR_RELEASE+x} ]; then \
-	LIDARR_RELEASE=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux" \
-	| jq -r '.[0].version'); \
+ LIDARR_JSON=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux") && \
+ LIDARR_RELEASE=$(jq -n "$LIDARR_JSON" | jq -r '.[0].version') && \
+ LIDARR_URL=$(jq -n "$LIDARR_JSON" | jq -r '.[0].url'); \
  fi && \
- lidarr_url=$(curl -sL "https://services.lidarr.audio/v1/update/${LIDARR_BRANCH}/changes?os=linux" \
-	| jq -r "first(.[] | select(.version == \"${LIDARR_RELEASE}\")) | .url") && \
+ set -ex && \
  curl -o \
  /tmp/lidarr.tar.gz -L \
-	"${lidarr_url}" && \
+	"${LIDARR_URL}" && \
  tar ixzf \
  /tmp/lidarr.tar.gz -C \
 	/app/lidarr --strip-components=1 && \
+ set +ex && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -41,6 +41,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "08.03.19:", desc: "Use single curl to hit endpoint, then parse the json twice locally" }
   - { date: "08.03.19:", desc: "Rebase to Bionic, use proposed endpoint for libchromaprint." }
   - { date: "26.01.19:", desc: "Add pipeline logic and multi arch." }
   - { date: "22.04.18:", desc: "Switch to beta builds." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ hits the endpoint with curl only once
+ jq the json locally twice , for VERSION and URL fields
+ set -ex to expose the version being fetched in the build log
+ and set it back to +ex after fetch for cleaner build log.