### PR TITLE
Fix typo in Readme

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -28,7 +28,7 @@ param_env_vars:
 # optional env variables
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "UMASK_SET", env_value: "022", desc: "control permissions of files and directories created by Sonarr"}
+  - { env_var: "UMASK_SET", env_value: "022", desc: "control permissions of files and directories created by Lidarr."}
 
 param_usage_include_vols: true
 param_volumes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
This simple PR fix a typo in the Readme, changing `Sonarr` to `Lidarr`.

##  Thanks, team linuxserver.io

