### PR TITLE
fix: improve curl options in custom_version_command

### DIFF
--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,7 @@
 # jenkins variables
 project_name: docker-lidarr
 external_type: na
-custom_version_command: curl -sL "https://lidarr.servarr.com/v1/update/master/changes?runtime=netcore%26os=linuxmusl" | jq -r '.[0].version'
+custom_version_command: curl --fail --silent --show-error --location "https://lidarr.servarr.com/v1/update/master/changes?runtime=netcore%26os=linuxmusl" | jq -r '.[0].version // empty'
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
- [x] I have read the contributing guideline and understand that I have made the correct modifications
## Description:
Improve the curl command in `custom_version_command` by adding proper error handling flags.

**Changes:**
- Add `--fail` - return error on HTTP failure
- Add `--silent` - no progress meter  
- Add `--show-error` - show error with --silent
- Add `--location` - follow redirects
- Add `// empty` fallback - prevent null values

## Benefits of this PR and context:
- Prevents silent failures when curl encounters HTTP errors
- Makes the build more robust and debuggable
- No functional change to the resulting version output

## How Has This Been Tested?
- ✅ YAML syntax validated
- ✅ Command works locally (returns correct version 3.1.0.4875)
- ✅ No changes to auto-generated files (Jenkinsfile, README.md)

## Source / References:
- https://curl.se/docs/manpage.html
- https://stedolan.github.io/jq/manual/